### PR TITLE
use info instead of error

### DIFF
--- a/src/oc/search/app.clj
+++ b/src/oc/search/app.clj
@@ -31,7 +31,7 @@
       "entry-delete" (ocsearch/delete-entry msg-body)
       "board-index" (ocsearch/index-board msg-body)
       "board-delete" (ocsearch/delete-board msg-body)
-      (timbre/error "Unrecognized message type" msg-body)))
+      (timbre/info "Unrecognized message type" msg-body)))
   (sqs/ack done-channel msg))
 
 


### PR DESCRIPTION
https://sentry.io/opencompany/oc-staging-search/issues/430478176/

The sentry message was a result of using `timbre/error`.  I changed to use `info`.  Since there are messages we are ignoring such as organization notifications.