### PR TITLE
Filter private entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ To create a production build run:
 lein build
 ```
 
+## Reindexing
+
+To remove the current search index:
+
+```
+curl -i -X DELETE http://localhost:9200/<INDEX-NAME>
+```
+
+To reindex, see the [steps in the README](https://github.com/open-company/open-company-storage#force-initial-indexing-or-re-indexing) of the Search Service.
 
 ## Testing
 

--- a/src/oc/search/elastic_search.clj
+++ b/src/oc/search/elastic_search.clj
@@ -170,7 +170,7 @@
                 ["access" (:access board)]
                 ["viewer-id" (:viewers board)]
                 ["board-author-id" (:authors board)]]
-        script (apply str
+        script (clojure.string/join
                       (map (fn [[key value]]
                              (str "ctx._source['" key "'] = "
                                   (json/generate-string value) ";\n"))


### PR DESCRIPTION
Should now properly index board author and viewer data so that the private entries can be filtered out.

To test

* create a private board and an entry
* login as a user that doesn't have access to the board and search for that entry.
- [x]  the entry should NOT show up
* as the first user, add the second user to the private board
- [x] as the second user the entry should now show up in the result
* as the first user , remove the second user from the board
- [x] the entry should now be missing from the results
* as the first user, add the second user as a viewer of the board
- [x] the entry should show up in the second user's results.
 
All good - do the merge/deploy dance