### PR TITLE
Add transcript to search index.

### DIFF
--- a/src/oc/search/elastic_search.clj
+++ b/src/oc/search/elastic_search.clj
@@ -103,7 +103,7 @@
      :published-at (:published-at entry)
      :shared-at (:shared-at (last (:shared entry)))
      :created-at (:created-at entry)
-     :body (:body entry)}))
+     :body (str (:video-transcript entry) (:body entry))}))
 
 (defn- map-board
   [data]


### PR DESCRIPTION
This change simply adds the video transcription data to the body so that it is searchable.

To test, create a video post with the search service running.  Search on transcription data to see if the post shows up.